### PR TITLE
Don't wipe out the action links on other Network Admin Plugins screens

### DIFF
--- a/loader.php
+++ b/loader.php
@@ -73,7 +73,7 @@ add_action( 'pre_current_active_plugins', function() use ( $hm_mu_plugins ) {
 
 add_action( 'network_admin_plugin_action_links', function( $actions, $plugin_file, $plugin_data, $context ) use ( $hm_mu_plugins ) {
 	if ( $context !== 'mustuse' || ! in_array( $plugin_file, $hm_mu_plugins, true ) ) {
-		return [];
+		return $actions;
 	}
 
 	$actions[] = sprintf( '<span style="color:#333">File: <code>%s</code></span>', $plugin_file );


### PR DESCRIPTION
Fixes #1.

To test:

* Visit the Network Admin -> Plugins screen
* Observe that action links on plugins other than Must-Use plugins are available