### PR TITLE
Automatically discover installed MU plugins, and autoload them

### DIFF
--- a/class-plugin.php
+++ b/class-plugin.php
@@ -66,7 +66,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 
 		// Discover installed mu-plugins if none are explicitly defined
 		// "Explicitly defined" includes the presence of the "mu-plugins" key in "extra"
-		if ( ! array_key_exists( 'mu-plugins', $extra ) ) {
+		if ( ! array_key_exists( 'mu-plugins', $extra ) && file_exists( $dest_dir ) && is_dir( $dest_dir ) ) {
 			foreach ( scandir( $dest_dir ) as $mu_plugin_dir ) {
 				$full_mu_plugin_dir = sprintf( '%s/%s', $dest_dir, $mu_plugin_dir );
 				if ( is_dir( $full_mu_plugin_dir ) && ! str_starts_with( $mu_plugin_dir, '.' ) ) {
@@ -97,6 +97,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 			$loader = str_replace( '$hm_mu_plugins = []', '$hm_mu_plugins = ' . var_export( $hm_mu_plugins, true ), $loader );
 		}
 
+		if ( ! file_exists( $dest_dir ) ) {
+			mkdir( $dest_dir, 0777, true );
+		}
 		file_put_contents( $dest_file, $loader );
 	}
 


### PR DESCRIPTION
If the "mu-plugins" key is not present in "extra" in composer.json, look for folders in the mu-plugins directory, find their entrypoint PHP file, and add them to the list of plugins to autoload.

If the "mu-plugins" key is defined (whether it's empty or not), the existing behavior is preserved and that list is used as-is.